### PR TITLE
fix: adapt compose file to changed papercut docker image

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -36,7 +36,7 @@ services:
     image: changemakerstudiosus/papercut-smtp:latest
     restart: unless-stopped
     ports:
-      - "8080:80"
+      - "8080:8080"
 
   test_conf_phpmyadmin:
     container_name: test_conf_phpmyadmin


### PR DESCRIPTION
It seems there have been changes to the Docker image of Papercut (the dev email server we use): Previously, their web interface opened on port 80, but now it opens on port 8080. Therefore I had to adapt the compose file to make it work again.